### PR TITLE
feat: Support full Chinese character with new font

### DIFF
--- a/public/templates/chicv.typ
+++ b/public/templates/chicv.typ
@@ -58,6 +58,7 @@
 #let chicv(body) = {
     let fonts = (
         "Palatino",
+        "Noto Serif CJK SC",
         "Source Han Serif SC",
         "Noto Serif SC",
     )

--- a/src/components/Preview.vue
+++ b/src/components/Preview.vue
@@ -17,10 +17,14 @@ const initTypst = async () => {
   $typst.setCompilerInitOptions({
     beforeBuild: [
       loadFonts([
+        // Font Awesome icons
         'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/webfonts/fa-solid-900.ttf',
         'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/webfonts/fa-brands-400.ttf',
-        'https://cdn.jsdelivr.net/npm/@fontsource/noto-serif-sc@5.0.12/files/noto-serif-sc-chinese-simplified-400-normal.woff',
-        'https://cdn.jsdelivr.net/npm/@fontsource/noto-serif-sc@5.0.12/files/noto-serif-sc-chinese-simplified-700-normal.woff'
+        // Full Noto Serif CJK SC fonts from Google/Adobe's official noto-cjk repository
+        // These contain the complete CJK character set including rare characters like "烬"
+        // Using raw.githubusercontent.com as it supports large font files
+        'https://raw.githubusercontent.com/notofonts/noto-cjk/main/Serif/OTF/SimplifiedChinese/NotoSerifCJKsc-Regular.otf',
+        'https://raw.githubusercontent.com/notofonts/noto-cjk/main/Serif/OTF/SimplifiedChinese/NotoSerifCJKsc-Bold.otf'
       ], {
         assets: ['text', 'cjk']
       })


### PR DESCRIPTION
Replace subset font with full OTF font from noto-cjk repository to support rare Chinese characters like '烬' that were previously not rendering.

Changes:
- Update font URLs in Preview.vue to use complete Noto Serif CJK SC fonts from raw.githubusercontent.com/notofonts/noto-cjk (~24.5MB per font)
- Add 'Noto Serif CJK SC' as primary CJK font in chicv.typ template

The full font contains the complete CJK character set with 65,000+ glyphs, covering GB18030 standard and supporting all non-extremely-rare characters.

Closes #13